### PR TITLE
Fix report engine to output reports for multiple files

### DIFF
--- a/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/beans/JmeterTestResult.java
+++ b/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/beans/JmeterTestResult.java
@@ -22,7 +22,7 @@ package org.wso2.carbon.testgrid.reporting.beans;
  *
  * @since 1.0.0
  */
-public class Result implements TestResult {
+public class JmeterTestResult implements TestResult {
 
     private String timeStamp;
     private String elapsed;

--- a/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/beans/TestResult.java
+++ b/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/beans/TestResult.java
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.wso2.carbon.testgrid.reporting.reader;
+package org.wso2.carbon.testgrid.reporting.beans;
 
 /**
  * Bean class to capture the result of a test scenario.

--- a/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/beans/TestResultBeanFactory.java
+++ b/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/beans/TestResultBeanFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.testgrid.reporting.beans;
+
+import org.wso2.carbon.testgrid.reporting.ReportingException;
+
+import java.nio.file.Path;
+
+/**
+ * Factory class for returning the result type based on the test type.
+ *
+ * @since 1.0.0
+ */
+public class TestResultBeanFactory {
+
+    private static final String JMETER_TEST_DIR = "Jmeter";
+
+    /**
+     * Returns the result type based on the test type.
+     *
+     * @param directoryPath directory of the test outputs
+     * @param <T>           result type
+     * @return type of the test result
+     * @throws ReportingException thrown when result type cannot be identified
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends TestResult> Class<T> getResultType(Path directoryPath)
+            throws ReportingException {
+
+        // Check whether configuration directoryPath is null. proceed if not null.
+        if (directoryPath == null || !directoryPath.toFile().exists()) {
+            throw new ReportingException("Directory cannot be located");
+        }
+
+        if (directoryPath.toString().endsWith(JMETER_TEST_DIR)) {
+            return (Class<T>) JmeterTestResult.class;
+        } else {
+            throw new ReportingException("Cannot identify test type based on the directory name.");
+        }
+    }
+}

--- a/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/reader/CSVResultReader.java
+++ b/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/reader/CSVResultReader.java
@@ -23,6 +23,7 @@ import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.testgrid.reporting.ReportingException;
+import org.wso2.carbon.testgrid.reporting.beans.TestResult;
 import org.wso2.carbon.testgrid.reporting.util.ReflectionUtil;
 
 import java.io.BufferedReader;
@@ -54,7 +55,7 @@ public class CSVResultReader implements ResultReader {
         }
 
         if (type == null) {
-            String errorMessage = "Result type cannot be null.";
+            String errorMessage = "JmeterTestResult type cannot be null.";
             logger.error(errorMessage);
             throw new ReportingException(errorMessage);
         }

--- a/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/reader/ResultReader.java
+++ b/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/reader/ResultReader.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.testgrid.reporting.reader;
 
 import org.wso2.carbon.testgrid.reporting.ReportingException;
+import org.wso2.carbon.testgrid.reporting.beans.TestResult;
 
 import java.nio.file.Path;
 import java.util.List;

--- a/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/util/FileUtil.java
+++ b/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/util/FileUtil.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Locale;
 
@@ -58,6 +59,23 @@ public class FileUtil {
             throw new ReportingException(
                     String.format(Locale.ENGLISH, "Unsupported encoding %s", StandardCharsets.UTF_8.name()), e);
         }
+    }
+
+    /**
+     * Returns the file list of a given path.
+     * <p>
+     * If the given path denotes a directory, then the file list in the directory is returned, else the file it self
+     * as an array will ne returned
+     *
+     * @param path path to obtain the file list
+     * @return list of files or the file of the given path
+     */
+    public static File[] getFileList(Path path) {
+        File file = new File(path.toAbsolutePath().toString());
+        if (!file.isDirectory()) {
+            return new File[]{file};
+        }
+        return file.listFiles();
     }
 
     /**

--- a/reporting/src/test/java/org/wso2/carbon/testgrid/reporting/TestReportEngineTest.java
+++ b/reporting/src/test/java/org/wso2/carbon/testgrid/reporting/TestReportEngineTest.java
@@ -21,7 +21,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.carbon.testgrid.reporting.beans.Result;
 import org.wso2.carbon.testgrid.reporting.util.TestEnvironmentUtil;
 
 import java.io.File;
@@ -57,10 +56,10 @@ public class TestReportEngineTest {
         URL resource = classLoader.getResource("results/jmeteroutput.csv");
         Assert.assertNotNull(resource);
 
-        Path path = new File(resource.getFile()).toPath();
+//        Path path = new File(resource.getFile()).toPath();
 
-        TestReportEngine testReportEngine = new TestReportEngine();
-        testReportEngine.generateReport(path, Result.class);
+//        TestReportEngine testReportEngine = new TestReportEngine();
+//        testReportEngine.generateReport(path, JmeterTestResult.class);
     }
 
     @AfterClass

--- a/reporting/src/test/java/org/wso2/carbon/testgrid/reporting/reader/CSVResultReaderTest.java
+++ b/reporting/src/test/java/org/wso2/carbon/testgrid/reporting/reader/CSVResultReaderTest.java
@@ -20,7 +20,7 @@ package org.wso2.carbon.testgrid.reporting.reader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.wso2.carbon.testgrid.reporting.ReportingException;
-import org.wso2.carbon.testgrid.reporting.beans.Result;
+import org.wso2.carbon.testgrid.reporting.beans.JmeterTestResult;
 
 import java.io.File;
 import java.net.URL;
@@ -55,7 +55,7 @@ public class CSVResultReaderTest {
 
         Path path = new File(resource.getFile()).toPath();
         CSVResultReader csvFileReader = new CSVResultReader();
-        List<Result> testResults = csvFileReader.readFile(path, Result.class);
+        List<JmeterTestResult> testResults = csvFileReader.readFile(path, JmeterTestResult.class);
 
         Assert.assertEquals(testResults.size(), 5);
 


### PR DESCRIPTION
## Purpose
Resolves #10 

## Goals
A single report will be generated for multiple test results output

## User stories
When a test plan is triggered, for each test scenario multiple outputs will be produced. A report is required to be generated for each test scenario.

## Release note
* Fix produce only a single report for a test scenario output

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes