### PR TITLE
Updated InfrastructureProvider to support script execution

### DIFF
--- a/common/src/main/java/org/wso2/carbon/testgrid/common/InfrastructureProvider.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/InfrastructureProvider.java
@@ -34,22 +34,31 @@ public interface InfrastructureProvider {
      String getProviderName();
 
     /**
+     * This method returns whether the provider can handle the requested infrastructure.
+     *
+     * @return A boolean indicating whether can handle or not.
+     */
+     boolean canHandle(Infrastructure infrastructure);
+
+    /**
      * This method creates the necessary infrastructure using the provided configuration.
      *
      * @param infrastructure An instance of a Infrastructure which includes the details of the infrastructure
      *                       that should be created.
+     * @param infraRepoDir - Location of the cloned repository related to infrastructure.
      * @return Deployment -  Deployment object including the created host, ip details
      * @throws TestGridInfrastructureException
      */
-    Deployment createInfrastructure(Infrastructure infrastructure) throws TestGridInfrastructureException;
+    Deployment createInfrastructure(Infrastructure infrastructure, String infraRepoDir) throws TestGridInfrastructureException;
 
     /**
      * This method executes commands needed to remove the infrastructure.
      *
      * @param deployment An instance of a Deployment which Infrastructure should be removed.
+     * @param infraRepoDir - Location of the cloned repository related to infrastructure.
      * @return boolean status of the operation
      * @throws TestGridInfrastructureException
      */
-    boolean removeInfrastructure(Deployment deployment) throws TestGridInfrastructureException;
+    boolean removeInfrastructure(Deployment deployment, String infraRepoDir) throws TestGridInfrastructureException;
 
 }

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/Script.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/Script.java
@@ -33,7 +33,7 @@ public class Script {
     private int order;
 
     public enum ScriptType {
-        CLOUD_FORMATION ("Cloud Formation"), INFRA_CREATE ("Shell"), INFRA_DESTROY ("Shell Destroy");
+        CLOUD_FORMATION ("Cloud Formation"), INFRA_CREATE ("Infra Create"), INFRA_DESTROY ("Infra Destroy");
 
         private final String name;
 

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/Script.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/Script.java
@@ -33,7 +33,7 @@ public class Script {
     private int order;
 
     public enum ScriptType {
-        CLOUD_FORMATION ("Cloud Formation"), SHELL ("Shell");
+        CLOUD_FORMATION ("Cloud Formation"), INFRA_CREATE ("Shell"), INFRA_DESTROY ("Shell Destroy");
 
         private final String name;
 

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/TestPlan.java
@@ -35,7 +35,8 @@ public class TestPlan {
     private long completedTimeStamp;
     //Dir of TestPlan home directory
     private String home;
-    private String repoDir;
+    private String testRepoDir;
+    private String infraRepoDir;
     private Status status;
     private TestReport testReport;
     private Deployment deployment;
@@ -58,9 +59,23 @@ public class TestPlan {
     private Script deploymentScript;
 
     public enum Status {
-        EXECUTION_PLANNED, INFRASTRUCTURE_PREPARATION, INFRASTRUCTURE_READY, INFRASTRUCTURE_ERROR, DEPLOYMENT_PREPARATION,
-        DEPLOYMENT_READY, DEPLOYMENT_ERROR, SCENARIO_EXECUTION, SCENARIO_EXECUTION_ERROR, SCENARIO_EXECUTION_COMPLETED,
-        REPORT_GENERATION, REPORT_GENERATION_ERROR, EXECUTION_COMPLETED
+        EXECUTION_PLANNED ("Execution Planned"), INFRASTRUCTURE_PREPARATION ("Infrastructure Preparation"),
+        INFRASTRUCTURE_READY ("Infrastructure Ready"), INFRASTRUCTURE_ERROR ("Infrastructure Error"),
+        INFRASTRUCTURE_DESTROY_ERROR ("Infrastructure Destroy Error"), DEPLOYMENT_PREPARATION ("Deployment Preparation"),
+        DEPLOYMENT_READY ("Deployment Ready"), DEPLOYMENT_ERROR ("Deployment Error"),
+        SCENARIO_EXECUTION ("Scenario Execution"), SCENARIO_EXECUTION_ERROR ("Scenario Execution Error"),
+        SCENARIO_EXECUTION_COMPLETED ("Scenario Execution Completed"), REPORT_GENERATION ("Report Generation"),
+        REPORT_GENERATION_ERROR ("Report Generation Error"), EXECUTION_COMPLETED ("Execution Completed");
+
+        private final String name;
+
+        Status(String s) {
+            name = s;
+        }
+
+        public String toString() {
+            return this.name;
+        }
     }
 
     public enum DeployerType {
@@ -185,12 +200,12 @@ public class TestPlan {
         this.description = description;
     }
 
-    public String getRepoDir() {
-        return repoDir;
+    public String getTestRepoDir() {
+        return testRepoDir;
     }
 
-    public void setRepoDir(String repoDir) {
-        this.repoDir = repoDir;
+    public void setTestRepoDir(String testRepoDir) {
+        this.testRepoDir = testRepoDir;
     }
 
     public Script getInfrastructureScript() {
@@ -207,5 +222,13 @@ public class TestPlan {
 
     public void setDeploymentScript(Script deploymentScript) {
         this.deploymentScript = deploymentScript;
+    }
+
+    public String getInfraRepoDir() {
+        return infraRepoDir;
+    }
+
+    public void setInfraRepoDir(String infraRepoDir) {
+        this.infraRepoDir = infraRepoDir;
     }
 }

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/TestPlan.java
@@ -92,142 +92,319 @@ public class TestPlan {
         }
     }
 
+    /**
+     * Returns the id of the test plan.
+     *
+     * @return id of the test plan
+     */
     public int getId() {
         return id;
     }
 
+    /**
+     * Sets the id of the test plan.
+     *
+     * @param id - Generated id of the test plan
+     */
     public void setId(int id) {
         this.id = id;
     }
 
+    /**
+     * Returns the list of TestScenarios available under this test plan.
+     *
+     * @return list of TestScenarios in the test plan
+     */
     public List<TestScenario> getTestScenarios() {
         return testScenarios;
     }
 
+    /**
+     * Sets the test scenarios to this test plan.
+     *
+     * @param testScenarios - Generated id of the test plan
+     */
     public void setTestScenarios(List<TestScenario> testScenarios) {
         this.testScenarios = testScenarios;
     }
 
+    /**
+     * Returns the home directory location of test plan.
+     *
+     * @return home directory location of the test plan
+     */
     public String getHome() {
         return home;
     }
 
+    /**
+     * Sets the home directory location of test plan.
+     *
+     * @param home - home directory location of the test plan
+     */
     public void setHome(String home) {
         this.home = home;
     }
 
+    /**
+     * Returns the created time of the test plan.
+     *
+     * @return the created time of the test plan
+     */
     public long getCreatedTimeStamp() {
         return createdTimeStamp;
     }
 
+    /**
+     * Sets the created time of test plan.
+     *
+     * @param createdTimeStamp - created time of the test plan
+     */
     public void setCreatedTimeStamp(long createdTimeStamp) {
         this.createdTimeStamp = createdTimeStamp;
     }
 
+    /**
+     * Returns the name of the test plan.
+     *
+     * @return the name of the test plan
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the name of test plan.
+     *
+     * @param name - name of the test plan
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Returns the deployment pattern name of the test plan in which it was created.
+     *
+     * @return the deployment pattern name of the test plan
+     */
     public String getDeploymentPattern() {
         return deploymentPattern;
     }
 
+    /**
+     * Sets the deployment pattern name of the test plan in which it was created.
+     *
+     * @param deploymentPattern - deployment pattern name of the test plan
+     */
     public void setDeploymentPattern(String deploymentPattern) {
         this.deploymentPattern = deploymentPattern;
     }
 
+    /**
+     * Returns the completed time of the test plan.
+     *
+     * @return the completed time of the test plan
+     */
     public long getCompletedTimeStamp() {
         return completedTimeStamp;
     }
 
+    /**
+     * Sets the completed time of the test plan.
+     *
+     * @param completedTimeStamp - completed time of the test plan
+     */
     public void setCompletedTimeStamp(long completedTimeStamp) {
         this.completedTimeStamp = completedTimeStamp;
     }
 
+    /**
+     * Returns the current status of the test plan.
+     *
+     * @return the status of the test plan
+     */
     public Status getStatus() {
         return status;
     }
 
+    /**
+     * Sets the status of the test plan.
+     *
+     * @param status - current status of the test plan
+     */
     public void setStatus(Status status) {
         this.status = status;
     }
 
+    /**
+     * Returns the deployer-type (puppet/ansible) of the test plan.
+     *
+     * @return the deployer-type (puppet/ansible) of the test plan
+     */
     public DeployerType getDeployerType() {
         return deployerType;
     }
 
-    public void setDeployerType(DeployerType deployerType) {
-        this.deployerType = deployerType;
-    }
-
-    public TestReport getTestReport() {
-        return testReport;
-    }
-
-    public void setTestReport(TestReport testReport) {
-        this.testReport = testReport;
-    }
-
-    public Deployment getDeployment() {
-        return deployment;
-    }
-
-    public void setDeployment(Deployment deployment) {
-        this.deployment = deployment;
-    }
-
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
-    }
-
+    /**
+     * Sets the deployer-type (puppet/ansible) of the test plan using the string value.
+     *
+     * @param deployerType - string deployer-type (puppet/ansible) of the test plan
+     */
     public void setDeployerType(String deployerType) {
         this.deployerType = DeployerType.valueOf(deployerType.toUpperCase());
     }
 
+    /**
+     * Sets the deployer-type (puppet/ansible) of the test plan.
+     *
+     * @param deployerType - deployer-type (puppet/ansible) of the test plan
+     */
+    public void setDeployerType(DeployerType deployerType) {
+        this.deployerType = deployerType;
+    }
+
+    /**
+     * Returns the test execution results of this test plan.
+     *
+     * @return the test execution results of this test plan
+     */
+    public TestReport getTestReport() {
+        return testReport;
+    }
+
+    /**
+     * Sets the test execution results of this test plan.
+     *
+     * @param testReport - the test execution results of this test plan
+     */
+    public void setTestReport(TestReport testReport) {
+        this.testReport = testReport;
+    }
+
+    /**
+     * Returns the deployment information of the test plan.
+     *
+     * @return the deployment information of the test plan
+     */
+    public Deployment getDeployment() {
+        return deployment;
+    }
+
+    /**
+     * Sets the deployment information of the test plan.
+     *
+     * @param deployment - the deployment information of the test plan
+     */
+    public void setDeployment(Deployment deployment) {
+        this.deployment = deployment;
+    }
+
+    /**
+     * Returns if the test plan is enabled or not.
+     *
+     * @return if the test plan is enabled or not
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Sets if the test plan is enabled or not.
+     *
+     * @param enabled - test plan is enabled or not
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Returns the description of the test plan.
+     *
+     * @return the name of the test plan
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Sets the description of the test plan.
+     *
+     * @param description - description of the test plan
+     */
     public void setDescription(String description) {
         this.description = description;
     }
 
+    /**
+     * Returns the path of the test plans' test artifacts.
+     *
+     * @return the path of the test plans' test artifacts.
+     */
     public String getTestRepoDir() {
         return testRepoDir;
     }
 
+    /**
+     * Sets the path of the test plans' test artifacts.
+     *
+     * @param testRepoDir - the path of the test plans' test artifacts.
+     */
     public void setTestRepoDir(String testRepoDir) {
         this.testRepoDir = testRepoDir;
     }
 
+    /**
+     * Returns the location of additional infrastructure scripts attached with this test plan.
+     *
+     * @return additional infrastructureScript script path
+     */
     public Script getInfrastructureScript() {
         return infrastructureScript;
     }
 
+    /**
+     * Sets an additional infrastructure script path to this test plan to be executed after the general infrastructure
+     * has completed.
+     *
+     * @param infrastructureScript - additional infrastructureScript script path
+     */
     public void setInfrastructureScript(Script infrastructureScript) {
         this.infrastructureScript = infrastructureScript;
     }
 
+    /**
+     * Returns the location of additional deployment scripts attached with this test plan.
+     *
+     * @return the location of additional deployment scripts
+     */
     public Script getDeploymentScript() {
         return deploymentScript;
     }
 
+    /**
+     * Sets an additional deployment script path to this test plan to be executed after the general deployment has
+     * completed.
+     *
+     * @param deploymentScript - additional deployment script path
+     */
     public void setDeploymentScript(Script deploymentScript) {
         this.deploymentScript = deploymentScript;
     }
 
+    /**
+     * Returns the path of the test plans' infrastructure artifacts.
+     *
+     * @return the path of the test plans' infrastructure artifacts
+     */
     public String getInfraRepoDir() {
         return infraRepoDir;
     }
 
+    /**
+     * Sets the path of the test plans' infrastructure artifacts.
+     *
+     * @param infraRepoDir - the path of the test plans' infrastructure artifacts
+     */
     public void setInfraRepoDir(String infraRepoDir) {
         this.infraRepoDir = infraRepoDir;
     }

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/TestPlan.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/TestPlan.java
@@ -69,8 +69,8 @@ public class TestPlan {
 
         private final String name;
 
-        Status(String s) {
-            name = s;
+        Status(String status) {
+            name = status;
         }
 
         public String toString() {
@@ -83,8 +83,8 @@ public class TestPlan {
 
         private final String name;
 
-        DeployerType(String s) {
-            name = s;
+        DeployerType(String deployer) {
+            name = deployer;
         }
 
         public String toString() {

--- a/core/src/main/java/org/wso2/carbon/testgrid/core/ScenarioExecutor.java
+++ b/core/src/main/java/org/wso2/carbon/testgrid/core/ScenarioExecutor.java
@@ -40,20 +40,21 @@ public class ScenarioExecutor {
      * @param  testScenario - An instance of TestScenario in which the tests should be executed.
      * @param  deployment - An instance of Deployment in which the tests should be executed against.
      * @param  homeDir - The location of cloned TestPlan.
-     * @return Returns the status of the operation
+     * @return Returns the modified TestScenario with status
      * @throws ScenarioExecutorException If something goes wrong while executing the TestScenario.
      */
-    public boolean runScenario(TestScenario testScenario, Deployment deployment, String homeDir)
+    public TestScenario runScenario(TestScenario testScenario, Deployment deployment, String homeDir)
             throws ScenarioExecutorException {
         try {
             testScenario.setStatus(TestScenario.Status.RUNNING);
             new TestEngineImpl().runScenario(testScenario, homeDir, deployment);
+            testScenario.setStatus(TestScenario.Status.COMPLETED);
         } catch (TestAutomationEngineException e) {
             testScenario.setStatus(TestScenario.Status.ERROR);
             throw new ScenarioExecutorException("Exception occurred while running the Tests for Solution Pattern '" +
                     testScenario.getSolutionPattern() + "'");
         }
-        return true;
+        return testScenario;
     }
 
     /**

--- a/core/src/main/resources/testplan1.yaml
+++ b/core/src/main/resources/testplan1.yaml
@@ -19,7 +19,7 @@ wso2.testgrid.testplan:
   enabled: true
   name: "TestPlan1"
   description: "Two node pattern test suite"
-  deploymentPattern: "two-node"
+  deploymentPattern: "single-node"
   deployerType: "PUPPET"
   testScenarios:
     -

--- a/core/src/main/resources/two-node.yaml
+++ b/core/src/main/resources/two-node.yaml
@@ -19,7 +19,7 @@ wso2.testgrid.infrastructure:
   providerType: "OPENSTACK"
   clusterType: "K8S"
   instanceType: "DOCKER_CONTAINERS"
-  name: "two-node"
+  name: "single-node"
   operatingSystem:
     name: "Ubuntu"
     version: "17.04"
@@ -29,6 +29,13 @@ wso2.testgrid.infrastructure:
   securityProperties:
     apiKey: "242424"
     sshKey: "abc.key"
+  scripts:
+    -
+     scriptType: "INFRA_CREATE"
+     fileName: "OpenStack/infra.sh"
+    -
+     scriptType: "INFRA_DESTROY"
+     fileName: "OpenStack/cluster-destroy.sh"
   nodes:
     -
      label: "wso2-gateway"

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -37,27 +37,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
-            <plugin>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.wso2.carbon.testgrid.infrastructure.openstack.ClusterDeployer</mainClass>
-                        </manifest>
-                    </archive>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/InfrastructureProviderFactory.java
+++ b/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/InfrastructureProviderFactory.java
@@ -32,23 +32,25 @@ public class InfrastructureProviderFactory {
 
     static ServiceLoader<InfrastructureProvider> providers = ServiceLoader.load(InfrastructureProvider.class);
 
-    public static InfrastructureProvider getInfrastructureProvider(Infrastructure.ProviderType providerType) throws
+    public static InfrastructureProvider getInfrastructureProvider(Infrastructure infrastructure) throws
             UnsupportedProviderException, InfrastructureProviderInitializationException {
+        String providerName = infrastructure.getProviderType().name();
 
         for (InfrastructureProvider provider : providers) {
-            if (providerType.name().equalsIgnoreCase(provider.getProviderName())) {
+
+            if (provider.canHandle(infrastructure)) {
                 try {
                     return provider.getClass().newInstance();
                 } catch (InstantiationException e) {
                     throw new InfrastructureProviderInitializationException("Exception occurred while instantiating the" +
-                            " InfrastructureProvider for requested type '" + providerType.name() + "'", e);
+                            " InfrastructureProvider for requested type '" + providerName + "'", e);
                 } catch (IllegalAccessException e) {
                     throw new InfrastructureProviderInitializationException("Exception occurred while instantiating the" +
-                            " InfrastructureProvider for requested type '" + providerType.name() + "'", e);
+                            " InfrastructureProvider for requested type '" + providerName + "'", e);
                 }
             }
         }
         throw new UnsupportedProviderException("Unable to find a InfrastructureProvider for requested type '" +
-                providerType.name() + "'");
+                providerName + "'");
     }
 }

--- a/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/InfrastructureProviderFactory.java
+++ b/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/InfrastructureProviderFactory.java
@@ -32,6 +32,12 @@ public class InfrastructureProviderFactory {
 
     static ServiceLoader<InfrastructureProvider> providers = ServiceLoader.load(InfrastructureProvider.class);
 
+    /**
+     * Returns a matching infrastructure provider to create the environment.
+     *
+     * @param infrastructure - an instance of the Infrastructure object
+     * @return the status of the test plan
+     */
     public static InfrastructureProvider getInfrastructureProvider(Infrastructure infrastructure) throws
             UnsupportedProviderException, InfrastructureProviderInitializationException {
         String providerName = infrastructure.getProviderType().name();

--- a/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/InfrastructureProviderServiceImpl.java
+++ b/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/InfrastructureProviderServiceImpl.java
@@ -39,7 +39,12 @@ public class InfrastructureProviderServiceImpl implements InfrastructureProvider
     }
 
     @Override
-    public Deployment createInfrastructure(Infrastructure infrastructure) throws TestGridInfrastructureException {
+    public boolean canHandle(Infrastructure infrastructure) {
+        return true;
+    }
+
+    @Override
+    public Deployment createInfrastructure(Infrastructure infrastructure, String infraRepoDir) throws TestGridInfrastructureException {
 //        String testPlanLocation = infrastructure.getHome() +"/test-grid-is-resources/DeploymentPatterns/" + infrastructure.getDeploymentPattern();
 //
 //        System.out.println("Initializing terraform...");
@@ -54,7 +59,7 @@ public class InfrastructureProviderServiceImpl implements InfrastructureProvider
     }
 
     @Override
-    public boolean removeInfrastructure(Deployment deployment) throws TestGridInfrastructureException {
+    public boolean removeInfrastructure(Deployment deployment, String infraRepoDir) throws TestGridInfrastructureException {
 //        String testPlanLocation = deployment.getHome() +"/test-grid-is-resources/DeploymentPatterns/" + deployment.getDeploymentPattern();
 //        System.out.println("Destroying test environment...");
 //        if(Utils.executeCommand("sh " + testPlanLocation + "/OpenStack/cluster-destroy.sh", null)) {

--- a/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/providers/OpenStackProvider.java
+++ b/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/providers/OpenStackProvider.java
@@ -39,12 +39,17 @@ public class OpenStackProvider implements InfrastructureProvider {
     }
 
     @Override
-    public Deployment createInfrastructure(Infrastructure infrastructure) throws TestGridInfrastructureException {
+    public boolean canHandle(Infrastructure infrastructure) {
+        return true;
+    }
+
+    @Override
+    public Deployment createInfrastructure(Infrastructure infrastructure, String infraRepoDir) throws TestGridInfrastructureException {
         return null;
     }
 
     @Override
-    public boolean removeInfrastructure(Deployment deployment) throws TestGridInfrastructureException {
+    public boolean removeInfrastructure(Deployment deployment, String infraRepoDir) throws TestGridInfrastructureException {
         return false;
     }
 }

--- a/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/TestReportEngineImpl.java
+++ b/reporting/src/main/java/org/wso2/carbon/testgrid/reporting/TestReportEngineImpl.java
@@ -111,7 +111,8 @@ public class TestReportEngineImpl implements TestReportEngine {
             List<TestScenarioReport> testScenarioReports = new ArrayList<>();
 
             for (TestScenario testScenario : testScenarios) {
-                Path resultPath = Paths.get(Utils.getTestScenarioLocation(testScenario, testPlan.getRepoDir()), TEST_ARTIFACT_DIR, RESULTS_DIR);
+                Path resultPath = Paths.get(Utils.getTestScenarioLocation(testScenario, testPlan.getTestRepoDir()),
+                        TEST_ARTIFACT_DIR, RESULTS_DIR);
                 File[] directoryList = FileUtil.getFileList(resultPath);
                 List<T> testResults = new ArrayList<>();
 

--- a/reporting/src/test/java/org/wso2/carbon/testgrid/reporting/TestReportEngineTest.java
+++ b/reporting/src/test/java/org/wso2/carbon/testgrid/reporting/TestReportEngineTest.java
@@ -33,9 +33,9 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Test class to test the functionality of the {@link TestReportEngineImpl}.
@@ -83,10 +83,10 @@ public class TestReportEngineTest {
         Mockito.when(testPlan.getTestScenarios()).thenReturn(testScenarios);
         Mockito.when(testPlan.getHome()).thenReturn(scenarioLocation);
 
-        List<TestPlan> testPlans = new ArrayList<>();
+        CopyOnWriteArrayList<TestPlan> testPlans = new CopyOnWriteArrayList<>();
         testPlans.add(testPlan);
 
-        Map<String, Infrastructure> infrastructureMap = new HashMap<>();
+        ConcurrentHashMap<String, Infrastructure> infrastructureMap = new ConcurrentHashMap<>();
         infrastructureMap.put(infrastructure.getName(), infrastructure);
 
         ProductTestPlan productTestPlan = Mockito.mock(ProductTestPlan.class);


### PR DESCRIPTION
## Purpose
This adds the functionality to accommodate shell script execution into the TestGrid Infrastructure module.
Resolves #43.

## Goals
To have Shell script execution as an infrastructure provider

## Approach
Included a canHandle method to be implemented by the InfrastructureProviders, so that the InfrastructureProviderFactory can get the supported implementation by invoking it.