### PR TITLE
Change DeployerService interface to accept Deployment object

### DIFF
--- a/common/src/main/java/org/wso2/carbon/testgrid/common/DeployerService.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/DeployerService.java
@@ -26,18 +26,18 @@ import org.wso2.carbon.testgrid.common.exception.TestGridDeployerException;
 public interface DeployerService {
 
     /**
-     * This method returns the provider name (AWS/GCP/Open Stack etc).
+     * This method returns the deployer name (Puppet/Ansible/Chef etc).
      *
-     * @return A String indicating the name of the provider.
+     * @return A String indicating the name of the deployer.
      */
     String getDeployerName();
 
     /**
-     * Runs deploy.sh script and deploys artifacts in the test cluster
+     * Runs deploy.sh script and deploys artifacts in the provided infrastructure
      *
-     * @param deployment Current test plan
-     * @return Deployment
-     * @throws TestGridDeployerException
+     * @param deployment - Deployment information of the infrastructure
+     * @return Deployment - Deployment object along with it's matched hosts and ports
+     * @throws TestGridDeployerException - thrown when error occurs in the product deployment process.
      */
     Deployment deploy(Deployment deployment) throws TestGridDeployerException;
 }

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/DeployerService.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/DeployerService.java
@@ -35,17 +35,9 @@ public interface DeployerService {
     /**
      * Runs deploy.sh script and deploys artifacts in the test cluster
      *
-     * @param testPlan Current test plan
+     * @param deployment Current test plan
      * @return Deployment
      * @throws TestGridDeployerException
      */
-    Deployment deploy(TestPlan testPlan) throws TestGridDeployerException;
-
-    /**
-     *
-     * @param testPlan Current test plan
-     * @return Deployment
-     * @throws TestGridDeployerException
-     */
-    boolean unDeploy(TestPlan testPlan) throws TestGridDeployerException;
+    Deployment deploy(Deployment deployment) throws TestGridDeployerException;
 }

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/Deployment.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/Deployment.java
@@ -27,20 +27,59 @@ public class Deployment {
 
     private String name;
     private List<Host> hosts;
+    private String deploymentScriptsDir;
 
+    /**
+     * Returns the name of the deployment.
+     *
+     * @return name of the deployment
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the name of the deployment.
+     *
+     * @param name - Name of the deployment
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Returns the list of hosts in the deployment.
+     *
+     * @return List of hosts in the deployment
+     */
     public List<Host> getHosts() {
         return hosts;
     }
 
+    /**
+     * Sets the list of hosts in the deployment.
+     *
+     * @param hosts - list of hosts in the deployment
+     */
     public void setHosts(List<Host> hosts) {
         this.hosts = hosts;
+    }
+
+    /**
+     * Returns the location of the deployment scripts.
+     *
+     * @return the location of the deployment scripts
+     */
+    public String getDeploymentScriptsDir() {
+        return deploymentScriptsDir;
+    }
+
+    /**
+     * Sets the location of the deployment scripts.
+     *
+     * @param deploymentScriptsDir - location of the deployment scripts
+     */
+    public void setDeploymentScriptsDir(String deploymentScriptsDir) {
+        this.deploymentScriptsDir = deploymentScriptsDir;
     }
 }

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/constants/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/constants/TestGridConstants.java
@@ -13,6 +13,5 @@ public class TestGridConstants {
     public static final String TEST_TYPE_TESTNG = "TESTNG";
 
     public static final String JMTER_SUFFIX = ".jmx";
-
     public static final String DEPLOYMENT_DIR = "DeploymentPatterns";
 }

--- a/common/src/main/java/org/wso2/carbon/testgrid/common/constants/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/constants/TestGridConstants.java
@@ -13,4 +13,6 @@ public class TestGridConstants {
     public static final String TEST_TYPE_TESTNG = "TESTNG";
 
     public static final String JMTER_SUFFIX = ".jmx";
+
+    public static final String DEPLOYMENT_DIR = "DeploymentPatterns";
 }

--- a/core/src/main/java/org/wso2/carbon/testgrid/core/TestPlanExecutor.java
+++ b/core/src/main/java/org/wso2/carbon/testgrid/core/TestPlanExecutor.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.testgrid.common.Deployment;
 import org.wso2.carbon.testgrid.common.Infrastructure;
 import org.wso2.carbon.testgrid.common.TestPlan;
 import org.wso2.carbon.testgrid.common.TestScenario;
+import org.wso2.carbon.testgrid.common.constants.TestGridConstants;
 import org.wso2.carbon.testgrid.common.exception.InfrastructureProviderInitializationException;
 import org.wso2.carbon.testgrid.common.exception.TestGridDeployerException;
 import org.wso2.carbon.testgrid.common.exception.TestGridInfrastructureException;
@@ -33,6 +34,7 @@ import org.wso2.carbon.testgrid.core.exception.TestPlanExecutorException;
 import org.wso2.carbon.testgrid.deployment.DeployerServiceImpl;
 import org.wso2.carbon.testgrid.infrastructure.InfrastructureProviderFactory;
 
+import java.nio.file.Paths;
 import java.util.Date;
 
 /**
@@ -48,8 +50,13 @@ public class TestPlanExecutor {
         try {
 
             if (infrastructure != null) {
-                testPlan.setDeployment(InfrastructureProviderFactory.getInfrastructureProvider(infrastructure)
-                        .createInfrastructure(infrastructure, testPlan.getInfraRepoDir()));
+                Deployment deployment = InfrastructureProviderFactory.getInfrastructureProvider(infrastructure)
+                        .createInfrastructure(infrastructure, testPlan.getInfraRepoDir());
+                deployment.setName(infrastructure.getName());
+                deployment.setDeploymentScriptsDir(Paths.get(testPlan.getInfraRepoDir(),
+                        TestGridConstants.DEPLOYMENT_DIR, infrastructure.getName(),
+                        infrastructure.getProviderType().name()).toString());
+                testPlan.setDeployment(deployment);
                 testPlan.setStatus(TestPlan.Status.INFRASTRUCTURE_READY);
             } else {
                 testPlan.setStatus(TestPlan.Status.INFRASTRUCTURE_ERROR);
@@ -125,7 +132,7 @@ public class TestPlanExecutor {
             testPlan.setStatus(TestPlan.Status.DEPLOYMENT_PREPARATION);
             Deployment deployment;
             try {
-                deployment = new DeployerServiceImpl().deploy(testPlan);
+                deployment = new DeployerServiceImpl().deploy(testPlan.getDeployment());
                 testPlan.setStatus(TestPlan.Status.DEPLOYMENT_READY);
             } catch (TestGridDeployerException e) {
                 testPlan.setStatus(TestPlan.Status.DEPLOYMENT_ERROR);


### PR DESCRIPTION
## Purpose
> Resolve #69 

## Goals
> This will enable implementations of DeployerService to fetch all necessary details from the Deployment object.

## Approach
> Updated Deployment object to hold the required parameters.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
