### PR TITLE
Add tests to AWS provider

### DIFF
--- a/common/src/main/java/org/wso2/carbon/testgrid/common/constants/TestGridConstants.java
+++ b/common/src/main/java/org/wso2/carbon/testgrid/common/constants/TestGridConstants.java
@@ -7,8 +7,8 @@ public class TestGridConstants {
 
     //environment variables
     public static final String JMETER_HOME = "JMETER_HOME";
-    public static final String AWS_ACCESS_KEY = "AWS_ACCESS_KEY";
-    public static final String AWS_SECRET_KEY = "AWS_SECRET_KEY";
+    public static final String AWS_ACCESS_KEY = "AWS_ACCESS_KEY_ID";
+    public static final String AWS_SECRET_KEY = "AWS_SECRET_ACCESS_KEY";
 
     //test types
     public static final String TEST_TYPE_JMETER = "JMETER";

--- a/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/aws/AWSManager.java
+++ b/infrastructure/src/main/java/org/wso2/carbon/testgrid/infrastructure/aws/AWSManager.java
@@ -76,8 +76,7 @@ public class AWSManager {
      * @return Returns a  Deployment object with created infrastructure details.
      * @throws TestGridInfrastructureException When there is an error with CloudFormation script.
      */
-    public Deployment createInfrastructure(Script script, String infraRepoDir) throws InterruptedException,
-            IOException, TestGridInfrastructureException {
+    public Deployment createInfrastructure(Script script, String infraRepoDir)throws TestGridInfrastructureException {
         String cloudFormationName = script.getName();
         AmazonCloudFormation stackbuilder = AmazonCloudFormationClientBuilder.standard()
                 .withCredentials(new EnvironmentVariableCredentialsProvider())

--- a/infrastructure/src/test/java/org/wso2/carbon/testgrid/infrastructure/AWSProviderTests.java
+++ b/infrastructure/src/test/java/org/wso2/carbon/testgrid/infrastructure/AWSProviderTests.java
@@ -28,34 +28,36 @@ import org.wso2.carbon.testgrid.common.Infrastructure;
 import org.wso2.carbon.testgrid.common.Script;
 import org.wso2.carbon.testgrid.infrastructure.aws.AWSManager;
 import org.wso2.carbon.testgrid.infrastructure.providers.AWSProvider;
-import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * This class tests the functionality of {@link AWSProvider}
  *
+ * @since 1.0.0
  */
-@PrepareForTest({AWSProvider.class,AWSManager.class})
-public class AWSProviderTests extends PowerMockTestCase{
+@PrepareForTest({AWSProvider.class, AWSManager.class})
+public class AWSProviderTests extends PowerMockTestCase {
 
     @Test(description = "This test case tests the provider name of AWSProvider.")
-    public void testGetProviderName(){
+    public void testGetProviderName() {
         AWSProvider provider = new AWSProvider();
         String providerName = provider.getProviderName();
         Assert.assertNotNull(providerName);
-        Assert.assertEquals(providerName,"AWS Provider");
+        Assert.assertEquals(providerName, "AWS Provider");
     }
 
-    @Test(description = "This test case tests if this provider can handle specific infrastructure script.")
-    public void testCanHandle(){
+    @Test(description = "This test case tests if this provider can handle specific " +
+            "infrastructure script.")
+    public void testCanHandle() {
         Infrastructure infrastructure = new Infrastructure();
         infrastructure.setProviderType(Infrastructure.ProviderType.AWS);
         Script script = new Script();
         script.setScriptType(Script.ScriptType.CLOUD_FORMATION);
-        infrastructure.setScripts(Arrays.asList(script));
+        infrastructure.setScripts(Collections.singletonList(script));
         AWSProvider provider = new AWSProvider();
         boolean b = provider.canHandle(infrastructure);
         Assert.assertNotNull(b);
-        Assert.assertEquals(b,true);
+        Assert.assertEquals(b, true);
     }
 
     @Test(description = "This test case tests the initiation of infrastructure creation request.")
@@ -64,15 +66,35 @@ public class AWSProviderTests extends PowerMockTestCase{
         infrastructure.setProviderType(Infrastructure.ProviderType.AWS);
         Script script = new Script();
         script.setScriptType(Script.ScriptType.CLOUD_FORMATION);
-        infrastructure.setScripts(Arrays.asList(script));
+        infrastructure.setScripts(Collections.singletonList(script));
         AWSProvider provider = new AWSProvider();
         AWSManager manager = Mockito.mock(AWSManager.class);
         Deployment deployment = new Deployment();
         deployment.setName("TestDeployment");
-        Mockito.when(manager.createInfrastructure(Mockito.any(Script.class),Mockito.anyString())).thenReturn(deployment);
+        Mockito.when(manager.createInfrastructure(Mockito.any(Script.class), Mockito.anyString()))
+                .thenReturn(deployment);
         PowerMockito.whenNew(AWSManager.class).withAnyArguments().thenReturn(manager);
-        Deployment abc = provider.createInfrastructure(infrastructure, "abc");
-        Assert.assertNotNull(abc);
-        Assert.assertEquals("TestDeployment",abc.getName());
+        Deployment response = provider.createInfrastructure(infrastructure, "dummyRepoDir");
+        Assert.assertNotNull(response);
+        Assert.assertEquals("TestDeployment", response.getName());
+    }
+
+    @Test(description = "This test case tests the functionality of removing existing CloudFormation " +
+            "stack given the script with stack name.")
+    public void testRemoveInfrastructure() throws Exception {
+        Infrastructure infrastructure = new Infrastructure();
+        infrastructure.setProviderType(Infrastructure.ProviderType.AWS);
+        Script script = new Script();
+        script.setScriptType(Script.ScriptType.CLOUD_FORMATION);
+        infrastructure.setScripts(Collections.singletonList(script));
+        AWSProvider provider = new AWSProvider();
+        AWSManager manager = Mockito.mock(AWSManager.class);
+        Deployment deployment = new Deployment();
+        deployment.setName("TestDeployment");
+        Mockito.when(manager.destroyInfrastructure(Mockito.any(Script.class))).thenReturn(true);
+        PowerMockito.whenNew(AWSManager.class).withAnyArguments().thenReturn(manager);
+        boolean removeInfrastructure = provider.removeInfrastructure(infrastructure, "dummyRepoDir");
+        Assert.assertNotNull(removeInfrastructure);
+        Assert.assertEquals(removeInfrastructure, true);
     }
 }

--- a/infrastructure/src/test/java/org/wso2/carbon/testgrid/infrastructure/AWSProviderTests.java
+++ b/infrastructure/src/test/java/org/wso2/carbon/testgrid/infrastructure/AWSProviderTests.java
@@ -1,0 +1,78 @@
+/*
+* Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+* WSO2 Inc. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+package org.wso2.carbon.testgrid.infrastructure;
+
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.wso2.carbon.testgrid.common.Deployment;
+import org.wso2.carbon.testgrid.common.Infrastructure;
+import org.wso2.carbon.testgrid.common.Script;
+import org.wso2.carbon.testgrid.infrastructure.aws.AWSManager;
+import org.wso2.carbon.testgrid.infrastructure.providers.AWSProvider;
+import java.util.Arrays;
+
+/**
+ * This class tests the functionality of {@link AWSProvider}
+ *
+ */
+@PrepareForTest({AWSProvider.class,AWSManager.class})
+public class AWSProviderTests extends PowerMockTestCase{
+
+    @Test(description = "This test case tests the provider name of AWSProvider.")
+    public void testGetProviderName(){
+        AWSProvider provider = new AWSProvider();
+        String providerName = provider.getProviderName();
+        Assert.assertNotNull(providerName);
+        Assert.assertEquals(providerName,"AWS Provider");
+    }
+
+    @Test(description = "This test case tests if this provider can handle specific infrastructure script.")
+    public void testCanHandle(){
+        Infrastructure infrastructure = new Infrastructure();
+        infrastructure.setProviderType(Infrastructure.ProviderType.AWS);
+        Script script = new Script();
+        script.setScriptType(Script.ScriptType.CLOUD_FORMATION);
+        infrastructure.setScripts(Arrays.asList(script));
+        AWSProvider provider = new AWSProvider();
+        boolean b = provider.canHandle(infrastructure);
+        Assert.assertNotNull(b);
+        Assert.assertEquals(b,true);
+    }
+
+    @Test(description = "This test case tests the initiation of infrastructure creation request.")
+    public void testCreateInfrastructure() throws Exception {
+        Infrastructure infrastructure = new Infrastructure();
+        infrastructure.setProviderType(Infrastructure.ProviderType.AWS);
+        Script script = new Script();
+        script.setScriptType(Script.ScriptType.CLOUD_FORMATION);
+        infrastructure.setScripts(Arrays.asList(script));
+        AWSProvider provider = new AWSProvider();
+        AWSManager manager = Mockito.mock(AWSManager.class);
+        Deployment deployment = new Deployment();
+        deployment.setName("TestDeployment");
+        Mockito.when(manager.createInfrastructure(Mockito.any(Script.class),Mockito.anyString())).thenReturn(deployment);
+        PowerMockito.whenNew(AWSManager.class).withAnyArguments().thenReturn(manager);
+        Deployment abc = provider.createInfrastructure(infrastructure, "abc");
+        Assert.assertNotNull(abc);
+        Assert.assertEquals("TestDeployment",abc.getName());
+    }
+}


### PR DESCRIPTION
## Purpose
 Resolves #64 

## Goals
Add Unit Tests to AWS Provider related classes.

## Approach
Test each method functionality of AWSProvider

## Automation tests
 - Unit tests 
 AWSProvider - 65% coverage
AWSManager - 79% coverage


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes