### PR TITLE
Fix java.lang.LinkageError in testgrid core

### DIFF
--- a/core/src/test/java/org/wso2/testgrid/core/ScenarioExecutorTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/ScenarioExecutorTest.java
@@ -21,6 +21,7 @@ package org.wso2.testgrid.core;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.Assert;
@@ -48,6 +49,7 @@ import static org.powermock.api.mockito.PowerMockito.whenNew;
  * @since 0.9.0
  */
 @PrepareForTest({DeployerFactory.class, TestEngineImpl.class, TestReportEngineImpl.class})
+@PowerMockIgnore({"javax.management.*"})
 public class ScenarioExecutorTest extends PowerMockTestCase {
 
     private static final Log log = LogFactory.getLog(ScenarioExecutorTest.class);

--- a/core/src/test/java/org/wso2/testgrid/core/TestGridMgtServiceTest.java
+++ b/core/src/test/java/org/wso2/testgrid/core/TestGridMgtServiceTest.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.Assert;
@@ -51,6 +52,7 @@ import java.net.URL;
  */
 @PrepareForTest({InfrastructureProviderFactory.class, TestGridUtil.class, TestEngineImpl.class,
         TestReportEngineImpl.class, TestPlanExecutor.class})
+@PowerMockIgnore({"javax.management.*"})
 public class TestGridMgtServiceTest extends PowerMockTestCase {
 
     private static final Log log = LogFactory.getLog(TestGridMgtServiceTest.class);


### PR DESCRIPTION
## Purpose
Resolves #94

This affected in `powermock` versions 1.6.0+ and Java 1.7_25+

## Goals
* Fix java.lang.LinkageError when running tests in testgrid core

## Release note
* Fixed java.lang.LinkageError when running tests in testgrid core

## Automation tests
 - Unit tests 
   > N/A - Fixing build exception when running tests
 - Integration tests
   > N/A - Fixing build exception when running tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes