### PR TITLE
Fix unused import checkstyle error

### DIFF
--- a/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/aws/AWSManager.java
+++ b/infrastructure/src/main/java/org/wso2/testgrid/infrastructure/aws/AWSManager.java
@@ -46,7 +46,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 


### PR DESCRIPTION
## Purpose
Removing the unused import that caused the build to fail.
resolves #234 